### PR TITLE
chore(bump): bump tmmc-lnpy from 0.8.0 to 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,31 @@
 
 <!-- markdownlint-disable-file -->
 
+
 Changelog for `tmmc-lnpy`
 
 See the fragment files in [changelog.d]
 
 <!-- prettier-ignore-end -->
 
+
 <!-- markdownlint-enable MD013 -->
 
+
 <!-- scriv-insert-here -->
+
+
+## 0.8.1
+
+Released on 2026-03-17.
+
+### Bug fixes
+
+- fix: pin coverage version in test-notebook ([#22](https://github.com/usnistgov/tmmc-lnpy/pull/22))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
 
 ## v0.8.0 — 2024-04-12
 
@@ -30,7 +46,7 @@ See the fragment files in [changelog.d]
 ### Added
 
 - Added type hints to most all code. Passing mypy (with strict) and pyright
-  (non-strict).
+(non-strict).
 - Clean up doc strings in several places.
 - Added nbval testing.
 - Ran linters across all code and notebooks.
@@ -40,7 +56,7 @@ See the fragment files in [changelog.d]
 ### Added
 
 - Now use [lazy_loader](https://github.com/scientific-python/lazy_loader) to
-  speed up initial load time.
+speed up initial load time.
 
 Full set of changes:
 [`v0.4.0...0.5.0`](https://github.com/usnistgov/tmmc-lnpy/compare/v0.4.0...v0.5.0)
@@ -50,19 +66,18 @@ Full set of changes:
 ### Added
 
 - Package now available on conda-forge Full set of changes:
-  [`v0.3.0...0.4.0`](https://github.com/usnistgov/tmmc-lnpy/compare/v0.3.0...v0.4.0)
+[`v0.3.0...0.4.0`](https://github.com/usnistgov/tmmc-lnpy/compare/v0.3.0...v0.4.0)
 
 ### Changed
 
 - Changed `examples.load_example_maskddata` to
-  `examples.load_example_lnpimasked` for consistency with other method names.
+`examples.load_example_lnpimasked` for consistency with other method names.
 
 ## v0.3.0 — 2023-05-02
 
 ### Added
 
 - Added support for python3.11
-
 - Moved `_docstrings` -> `docstrings` to make available
 - Moved from local docfiller to module_utilities.docfiller
 - Moved from local cached module to module-utilities.cached

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "tmmc-lnpy"
-version = "0.8.0"
+version = "0.8.1"
 description = "Analysis of lnPi results from TMMC simulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-03-10T21:28:43.377698Z"
+exclude-newer = "2026-03-10T21:36:36.397455837Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1192,7 +1192,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version != '3.12.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -4423,7 +4423,7 @@ wheels = [
 
 [[package]]
 name = "tmmc-lnpy"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)