### PR TITLE
chore(bump): bump tmmc-lnpy from 0.8.1 to 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ See the fragment files in [changelog.d]
 <!-- scriv-insert-here -->
 
 
+## 0.8.2
+
+Released on 2026-06-22.
+
+### Bug fixes
+
+- fix: apply minor fixes ([#159](https://github.com/usnistgov/tmmc-lnpy/pull/159))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.8.1
 
 Released on 2026-03-17.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "tmmc-lnpy"
-version = "0.8.1"
+version = "0.8.2"
 description = "Analysis of lnPi results from TMMC simulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -1290,7 +1290,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version != '3.12.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -4889,7 +4889,7 @@ wheels = [
 
 [[package]]
 name = "tmmc-lnpy"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)