### PR TITLE
fix: fix issues with joblib and tqdm

### DIFF
--- a/src/lnpy/core/joblib.py
+++ b/src/lnpy/core/joblib.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 from lnpy.options import OPTIONS
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable, Sequence
+    from collections.abc import Callable, Iterable, Iterator, Sequence
     from typing import Any, Literal
 
     from .typing_compat import TypeVar
@@ -17,28 +17,30 @@ if TYPE_CHECKING:
     R = TypeVar("R")
 
 
-HAS_JOBLIB = find_spec("joblib")
+HAS_JOBLIB: bool = find_spec("joblib") is not None
 
 
 def _use_joblib(
-    items: Sequence[Any],
     len_key: Literal["joblib_len_calc", "joblib_len_build"],
+    *,
     use_joblib: bool = True,
-    total: int | None = None,
+    total: int,
 ) -> bool:
-    if use_joblib and HAS_JOBLIB and OPTIONS["joblib_use"]:
-        if total is None:
-            total = len(items)
-        return total >= OPTIONS[len_key]
-    return False
+    return (
+        use_joblib
+        and HAS_JOBLIB
+        and OPTIONS["joblib_use"]
+        and total >= OPTIONS[len_key]
+    )
 
 
-def _parallel(seq: Iterable[Any]) -> list[Any]:
+def _parallel(seq: Iterable[Any]) -> Iterator[Any]:
     import joblib
 
     return cast(
-        "list[Any]",
+        "Iterator[Any]",
         joblib.Parallel(
+            return_as="generator",
             n_jobs=OPTIONS["joblib_n_jobs"],
             backend=OPTIONS["joblib_backend"],
             **OPTIONS["joblib_kws"],
@@ -47,15 +49,18 @@ def _parallel(seq: Iterable[Any]) -> list[Any]:
 
 
 def parallel_map_build(
-    func: Callable[..., R], items: Iterable[Any], *args: Any, **kwargs: Any
-) -> list[R]:
+    func: Callable[..., R],
+    items: Iterable[Any],
+    *args: Any,
+    total: int,
+    **kwargs: Any,
+) -> Iterator[R]:
 
-    items = tuple(items)
-    if _use_joblib(items, "joblib_len_build"):
+    if _use_joblib("joblib_len_build", total=total):
         import joblib
 
         return _parallel(joblib.delayed(func)(x, *args, **kwargs) for x in items)
-    return [func(x, *args, **kwargs) for x in items]
+    return (func(x, *args, **kwargs) for x in items)
 
 
 def _func_call(x: Callable[..., R], *args: Any, **kwargs: Any) -> R:
@@ -64,39 +69,42 @@ def _func_call(x: Callable[..., R], *args: Any, **kwargs: Any) -> R:
 
 def parallel_map_call(
     items: Sequence[Callable[..., Any]],
-    use_joblib: bool,  # noqa: ARG001
     *args: Any,
+    total: int,
     **kwargs: Any,
-) -> list[Any]:
-    if _use_joblib(items, "joblib_len_calc"):
+) -> Iterator[Any]:
+    if _use_joblib("joblib_len_calc", total=total):
         import joblib
 
         return _parallel(joblib.delayed(_func_call)(x, *args, **kwargs) for x in items)
-    return [x(*args, **kwargs) for x in items]
+    return (x(*args, **kwargs) for x in items)
 
 
-def parallel_map_attr(attr: str, use_joblib: bool, items: Sequence[Any]) -> list[Any]:  # noqa: ARG001
+def parallel_map_attr(
+    attr: str,
+    items: Sequence[Any],
+    total: int,
+) -> Iterator[Any]:
     from operator import attrgetter
 
     func = attrgetter(attr)
 
-    if _use_joblib(items, "joblib_len_calc"):
+    if _use_joblib("joblib_len_calc", total=total):
         import joblib
 
         return _parallel(joblib.delayed(func)(x) for x in items)
-    return [func(x) for x in items]
+    return (func(x) for x in items)
 
 
 def parallel_map_func_starargs(
     func: Callable[..., R],
-    use_joblib: bool,  # noqa: ARG001
     items: Iterable[Any],
-    total: int | None = None,
-) -> list[R]:
+    total: int,
+) -> Iterator[R]:
     items = tuple(items)
 
-    if _use_joblib(items, "joblib_len_calc", total=total):
+    if _use_joblib("joblib_len_calc", total=total):
         import joblib
 
         return _parallel(starmap(joblib.delayed(func), items))
-    return list(starmap(func, items))
+    return starmap(func, items)

--- a/src/lnpy/core/progress.py
+++ b/src/lnpy/core/progress.py
@@ -68,31 +68,28 @@ def tqdm(seq: Iterable[T], *args: Any, **kwargs: Any) -> Iterable[T]:
 def get_tqdm(
     seq: Iterable[T],
     len_min: int | Literal["tqdm_len_calc", "tqdm_len_build"],
+    *,
     leave: bool | None = None,
+    total: int,
     **kwargs: Any,
 ) -> Iterable[T]:
-    n = kwargs.get("total")
     if isinstance(len_min, str):
         len_min = OPTIONS[len_min]
 
-    if n is None:
-        seq = tuple(seq)
-        n = len(seq)
-
-    if HAS_TQDM and OPTIONS["tqdm_use"] and n >= len_min:
+    if HAS_TQDM and OPTIONS["tqdm_use"] and total >= len_min:
         if leave is None:
             leave = OPTIONS["tqdm_leave"]
-        seq = tqdm(seq, leave=leave, **kwargs)
+        seq = tqdm(seq, leave=leave, total=total, **kwargs)
     return seq
 
 
 def get_tqdm_calc(
-    seq: Iterable[T], leave: bool | None = None, **kwargs: Any
+    seq: Iterable[T], *, leave: bool | None = None, total: int, **kwargs: Any
 ) -> Iterable[T]:
-    return get_tqdm(seq, len_min="tqdm_len_calc", leave=leave, **kwargs)
+    return get_tqdm(seq, len_min="tqdm_len_calc", leave=leave, total=total, **kwargs)
 
 
 def get_tqdm_build(
-    seq: Iterable[T], leave: bool | None = None, **kwargs: Any
+    seq: Iterable[T], *, leave: bool | None = None, total: int, **kwargs: Any
 ) -> Iterable[T]:
-    return get_tqdm(seq, len_min="tqdm_len_build", leave=leave, **kwargs)
+    return get_tqdm(seq, len_min="tqdm_len_build", leave=leave, total=total, **kwargs)

--- a/src/lnpy/lnpienergy.py
+++ b/src/lnpy/lnpienergy.py
@@ -656,8 +656,6 @@ class wFreeEnergyCollectionBase:  # noqa: N801
 
     def __init__(self, parent: lnPiCollection) -> None:
         self._parent = parent
-        self._use_joblib = getattr(self._parent, "_use_joblib", False)
-
         self._cache: dict[str, Any] = {}
 
     def _get_items_ws(self) -> tuple[list[IndexAny], list[wFreeEnergy]]:
@@ -675,12 +673,18 @@ class wFreeEnergyCollectionBase:  # noqa: N801
     @cached.prop
     def _data(self) -> dict[str, pd.Series[Any]]:
         indexes, ws = self._get_items_ws()
+        total = len(ws)
+
         seq = get_tqdm(
-            zip(indexes, ws, strict=True), total=len(ws), desc="wFreeEnergyCollection"
+            parallel_map_func_starargs(
+                _get_w_data,
+                items=zip(indexes, ws, strict=True),
+                total=total,
+            ),
+            total=total,
+            desc="wFreeEnergyCollection",
         )
-        out = parallel_map_func_starargs(
-            _get_w_data, items=seq, use_joblib=self._use_joblib, total=len(ws)
-        )
+        out = list(seq)
 
         return {key: pd.concat([x[key] for x in out]) for key in out[0]}
 

--- a/src/lnpy/lnpiseries.py
+++ b/src/lnpy/lnpiseries.py
@@ -263,7 +263,6 @@ class lnPiCollection(AccessorMixin):  # noqa: PLR0904, N801
 
     _concat_dim = "sample"
     _concat_coords = "different"
-    _use_joblib = True
     _xarray_output = True
     _xarray_unstack = True
     _xarray_dot_kws: Final = {"optimize": "optimal"}
@@ -966,13 +965,18 @@ class lnPiCollection(AccessorMixin):  # noqa: PLR0904, N801
             build_kws = {}
 
         build_kws = dict(build_kws, phases_factory=False)
-        seq = get_tqdm(lnzs, desc="build")
+        total = len(lnzs)
+        seq = get_tqdm(
+            parallel_map(
+                build_phases, lnzs, total=total, ref=ref, nmax=nmax, **build_kws
+            ),
+            total=total,
+            desc="build",
+        )
 
         items: list[lnPiMasked] = []
         index: list[int] = []
-        for data, idx in parallel_map(
-            build_phases, seq, ref=ref, nmax=nmax, **build_kws
-        ):
+        for data, idx in seq:
             items += data
             index += list(idx)
         return cls.from_list(items, index, base_class=base_class, **kwargs)

--- a/src/lnpy/stability.py
+++ b/src/lnpy/stability.py
@@ -5,7 +5,7 @@ Thermodynamic stability (:mod:`~lnpy.stability`)
 Calculation of spinodal and binodal
 """
 
-# pylint: disable=chained-comparison,use-implicit-booleaness-not-comparison-to-zero
+# pylint: disable=use-implicit-booleaness-not-comparison-to-zero
 from __future__ import annotations
 
 import itertools

--- a/src/lnpy/stability.py
+++ b/src/lnpy/stability.py
@@ -269,7 +269,7 @@ def _refine_bracket_spinodal_right(
             # we've reached a breaking point
             if left_done:
                 # can't find a lower bound to efac, just return where we're at
-                root = float(left._get_lnz())
+                root = left._get_lnz()[idx]
                 r = rootresults(
                     root=root,
                     iterations=i + 1,


### PR DESCRIPTION
- Fix small bug in stability.py
- joblib.Parallel now uses `return_as='generator'`  This allows for better tqdm usage with joblib.Parallel
- Use explicit `total` parameter to `joblib.Parallel` and `tqdm`
