### PR TITLE
chore(bump): bump tmmc-lnpy from 0.8.2 to 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ See the fragment files in [changelog.d]
 <!-- scriv-insert-here -->
 
 
+## 0.8.3
+
+Released on 2026-06-23.
+
+### Bug fixes
+
+- fix: fix issues with joblib and tqdm ([#165](https://github.com/usnistgov/tmmc-lnpy/pull/165))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.8.2
 
 Released on 2026-06-22.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "tmmc-lnpy"
-version = "0.8.2"
+version = "0.8.3"
 description = "Analysis of lnPi results from TMMC simulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -4889,7 +4889,7 @@ wheels = [
 
 [[package]]
 name = "tmmc-lnpy"
-version = "0.8.2"
+version = "0.8.3"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)