### PR TITLE
chore(bump): bump tmmc-lnpy from 0.9.0 to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ See the fragment files in [changelog.d]
 <!-- scriv-insert-here -->
 
 
+## 0.9.1
+
+Released on 2026-06-26.
+
+### Bug fixes
+
+- fix: add Spinodal/Binodal exceptions ([#173](https://github.com/usnistgov/tmmc-lnpy/pull/173))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.9.0
 
 Released on 2026-06-26.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "tmmc-lnpy"
-version = "0.9.0"
+version = "0.9.1"
 description = "Analysis of lnPi results from TMMC simulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -4889,7 +4889,7 @@ wheels = [
 
 [[package]]
 name = "tmmc-lnpy"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)