### PR TITLE
chore(bump): bump tmmc-lnpy from 0.9.2 to 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ See the fragment files in [changelog.d]
 <!-- scriv-insert-here -->
 
 
+## 0.9.3
+
+Released on 2026-07-08.
+
+### Bug fixes
+
+- fix: add interpolate_na to lnPiMasked ([#185](https://github.com/usnistgov/tmmc-lnpy/pull/185))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.9.2
 
 Released on 2026-07-06.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "tmmc-lnpy"
-version = "0.9.2"
+version = "0.9.3"
 description = "Analysis of lnPi results from TMMC simulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -4982,7 +4982,7 @@ wheels = [
 
 [[package]]
 name = "tmmc-lnpy"
-version = "0.9.2"
+version = "0.9.3"
 source = { editable = "." }
 dependencies = [
     { name = "bottleneck" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)