### PR TITLE
chore(bump): bump tmmc-lnpy from 0.9.3 to 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ See the fragment files in [changelog.d]
 <!-- scriv-insert-here -->
 
 
+## 0.10.0
+
+Released on 2026-07-10.
+
+### Breaking changes
+
+- feat!: simplify phase_creator ([#188](https://github.com/usnistgov/tmmc-lnpy/pull/188))
+
+### Contributors
+
+- [@wpk-nist-gov](https://github.com/wpk-nist-gov)
+
 ## 0.9.3
 
 Released on 2026-07-08.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 
 [project]
 name = "tmmc-lnpy"
-version = "0.9.3"
+version = "0.10.0"
 description = "Analysis of lnPi results from TMMC simulation"
 readme = "README.md"
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -4996,7 +4996,7 @@ wheels = [
 
 [[package]]
 name = "tmmc-lnpy"
-version = "0.9.3"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
This is an autogenerated PR. Use this to bump the package version.

You may need to push an empty commit to restart ci (or close and open)