### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.14.2-24-g7630d38
+_commit: v0.14.3-1-gb74d734
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: none
 conda_channel: conda-forge

--- a/tools/shared.just
+++ b/tools/shared.just
@@ -23,8 +23,8 @@ nox *options:
 [group("lint")]
 [group("tools")]
 pre-commit *commands:
-    @[[ ! -f {{ CONSTRAINTS_MIN }} ]] && touch {{ CONSTRAINTS_MIN }} || true
-    {{ UVX }} --constraints={{ CONSTRAINTS_MIN }} prek {{ commands }} # using prek
+    @[[ ! -f {{ CONSTRAINTS_LOCK }} ]] && touch {{ CONSTRAINTS_LOCK }} || true
+    {{ UVX }} --constraints={{ CONSTRAINTS_LOCK }} prek {{ commands }} # using prek
 
 [group("lint")]
 [group("tools")]


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M tools/shared.just

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.